### PR TITLE
feat: allow customize prettier options

### DIFF
--- a/index.macro.js
+++ b/index.macro.js
@@ -1,14 +1,15 @@
-// ast-pretty-print is really handy :)
-const { createMacro } = require('babel-plugin-macros');
-const prettier = require('prettier');
+'use strict';
 
-module.exports = createMacro(function inlineJSXMacro({ references, babel }) {
+const { createMacro } = require('babel-plugin-macros');
+const prettier = require('prettier/standalone');
+
+const createInlineJSXMacro = prettierOpts => ({ references, babel }) {
   references.default.forEach(referencePath => {
     if (referencePath.parentPath.type === 'JSXOpeningElement') {
       const children = referencePath.parentPath.parentPath.get('children');
       const body = children[1].getSource();
-      let formattedBody = prettier.format(body, { parser: 'babel' });
-      if (formattedBody.endsWith(";\n")) {
+      let formattedBody = prettier.format(body, prettierOpts);
+      if (formattedBody.endsWith(';\n')) {
         formattedBody = formattedBody.substring(0, formattedBody.length - 2);
       }
       referencePath.parentPath.parentPath.replaceWith(
@@ -16,4 +17,6 @@ module.exports = createMacro(function inlineJSXMacro({ references, babel }) {
       );
     }
   });
-});
+}
+
+module.exports = prettierOpts => createMacro(createInlineJSXMacro(prettierOpts));


### PR DESCRIPTION
Hello,

This PR introduces a way to customize prettier support out of the box, being possible format any kind of code.

```js
import createInline from 'inlinejsx.macro'
import prettierParserHtml from 'prettier/parser-html'
import prettierParserGraphql from 'prettier/parser-graphql'
import prettierParserMarkdown from 'prettier/parser-markdown'
import parserBabel from 'prettier/parser-babel'

const BABEL_OPTS = {
  parser: 'babel',
  plugins: [parserBabel]
}

const JSON_OPTS = {
  parser: 'json',
  plugins: [parserBabel]
}

const HTML_OPTS = {
  parser: 'html',
  plugins: [prettierParserHtml]
}

const GRAPHQL_OPTS = {
  parser: 'graphql',
  plugins: [prettierParserGraphql]
}

const MARKDOWN_OPTS = {
  parser: 'markdown',
  plugins: [prettierParserMarkdown]
}

/**
 * https://prettier.io/docs/en/options.html
 */
const PRETTIER_CONFIG = {
  semi: false,
  singleQuote: true,
  jsxSingleQuote: true,
  printWidth: 80,
  tabWidth: 2
}

const InlineJSX = createInline({ ...BABEL_OPTS, ...PRETTIER_CONFIG })
const InlineJSON = createInline({ ...JSON_OPTS, ...PRETTIER_CONFIG })
const InlineHTML = createInline({ ...HTML_OPTS, ...PRETTIER_CONFIG })
const InlineGraphQL = createInline({ ...GRAPHQL_OPTS, ...PRETTIER_CONFIG })
const InlineMarkdown = createInline({ ...MARKDOWN_OPTS, ...PRETTIER_CONFIG })
```